### PR TITLE
closes #1 Add OAuth2 methods to allow integration with OAuth2 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ administrative rest API to query and manage the cache.
 | `GET`  | authorize | Authorizes the calling user            | N/A          |
 | `GET`  | whoami    | Returns details about the calling user | N/A          |
 
+### OAuth API
+
+| Method | Operation | Description                            | Request Body |
+|:---    |:---       |:---                                    |:---          |
+| `GET`  | authorize | For registered client_id and authorized user, return a short-lived code that can be used by the client to retrieve a user's JWT  | N/A  |
+| `POST` | token     | Using either a code from 'authorize' or a refresh_token, a registered can fetch the corresponding user's JWT                     | N/A  |
+| `GET`  | user      | Returns details about primary current (by token or PKI) user                                                                     | N/A  |
+| `GET`  | users     | Returns details about all current (by token or PKI) proxied users                                                                | N/A  |
+
 
 ### Admin API
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <version.guava>27.1-jre</version.guava>
         <version.jackson>2.9.9</version.jackson>
-        <version.jjwt>0.9.1</version.jjwt>
+        <version.jjwt>0.11.2</version.jjwt>
         <version.slf4j>1.7.26</version.slf4j>
     </properties>
     <dependencyManagement>
@@ -30,7 +30,12 @@
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
-                <artifactId>jjwt</artifactId>
+                <artifactId>jjwt-impl</artifactId>
+                <version>${version.jjwt}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.jsonwebtoken</groupId>
+                <artifactId>jjwt-jackson</artifactId>
                 <version>${version.jjwt}</version>
             </dependency>
             <dependency>
@@ -63,7 +68,11 @@
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
+            <artifactId>jjwt-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/api/src/main/java/datawave/security/authorization/DatawaveUser.java
+++ b/api/src/main/java/datawave/security/authorization/DatawaveUser.java
@@ -22,9 +22,11 @@ public class DatawaveUser implements Serializable {
         USER, SERVER
     }
     
-    public static final DatawaveUser ANONYMOUS_USER = new DatawaveUser(SubjectIssuerDNPair.of("ANONYMOUS"), UserType.USER, null, null, null, -1L);
+    public static final DatawaveUser ANONYMOUS_USER = new DatawaveUser(SubjectIssuerDNPair.of("ANONYMOUS"), UserType.USER, null, null, null, null, -1L);
     private final String name;
     private final String commonName;
+    private final String email;
+    private final String login;
     private final SubjectIssuerDNPair dn;
     private final UserType userType;
     private final Collection<String> auths;
@@ -37,17 +39,25 @@ public class DatawaveUser implements Serializable {
     
     public DatawaveUser(SubjectIssuerDNPair dn, UserType userType, Collection<String> auths, Collection<String> roles,
                     Multimap<String,String> roleToAuthMapping, long creationTime) {
-        this(dn, userType, auths, roles, roleToAuthMapping, creationTime, -1L);
+        this(dn, userType, null, auths, roles, roleToAuthMapping, creationTime, -1L);
+    }
+    
+    public DatawaveUser(SubjectIssuerDNPair dn, UserType userType, String email, Collection<String> auths, Collection<String> roles,
+                    Multimap<String,String> roleToAuthMapping, long creationTime) {
+        this(dn, userType, email, auths, roles, roleToAuthMapping, creationTime, -1L);
     }
     
     @JsonCreator
     public DatawaveUser(@JsonProperty(value = "dn", required = true) SubjectIssuerDNPair dn,
-                    @JsonProperty(value = "userType", required = true) UserType userType, @JsonProperty("auths") Collection<String> auths,
-                    @JsonProperty("roles") Collection<String> roles, @JsonProperty("roleToAuthMapping") Multimap<String,String> roleToAuthMapping,
+                    @JsonProperty(value = "userType", required = true) UserType userType, @JsonProperty("email") String email,
+                    @JsonProperty("auths") Collection<String> auths, @JsonProperty("roles") Collection<String> roles,
+                    @JsonProperty("roleToAuthMapping") Multimap<String,String> roleToAuthMapping,
                     @JsonProperty(value = "creationTime", defaultValue = "-1L") long creationTime,
                     @JsonProperty(value = "expirationTime", defaultValue = "-1L") long expirationTime) {
         this.name = dn.toString();
         this.commonName = ProxiedEntityUtils.getCommonName(dn.subjectDN());
+        this.login = ProxiedEntityUtils.getShortName(dn.subjectDN());
+        this.email = email;
         this.dn = dn;
         this.userType = userType;
         this.auths = auths == null ? Collections.emptyList() : new LinkedHashSet<>(auths);
@@ -67,6 +77,14 @@ public class DatawaveUser implements Serializable {
     @JsonIgnore
     public String getCommonName() {
         return commonName;
+    }
+    
+    public String getLogin() {
+        return login;
+    }
+    
+    public String getEmail() {
+        return email;
     }
     
     public SubjectIssuerDNPair getDn() {

--- a/api/src/main/java/datawave/security/authorization/OAuthConstants.java
+++ b/api/src/main/java/datawave/security/authorization/OAuthConstants.java
@@ -1,0 +1,20 @@
+package datawave.security.authorization;
+
+public class OAuthConstants {
+    
+    /*
+     * Use this grant type in the token API call after receiving an authorization code from the authorize API call
+     */
+    public static final String GRANT_AUTHORIZATION_CODE = "authorization_code";
+    
+    /*
+     * Use this grant type in the token API call to get a new token using the (longer lived) refresh token which is passed as a parameter
+     */
+    public static final String GRANT_REFRESH_TOKEN = "refresh_token";
+
+    /*
+     * Expected response type of code for the authorization operation.  Required by specification and the only allowed value for code flow
+     */
+    public static final String RESPONSE_TYPE_CODE = "code";
+
+}

--- a/api/src/main/java/datawave/security/authorization/OAuthConstants.java
+++ b/api/src/main/java/datawave/security/authorization/OAuthConstants.java
@@ -11,10 +11,10 @@ public class OAuthConstants {
      * Use this grant type in the token API call to get a new token using the (longer lived) refresh token which is passed as a parameter
      */
     public static final String GRANT_REFRESH_TOKEN = "refresh_token";
-
+    
     /*
-     * Expected response type of code for the authorization operation.  Required by specification and the only allowed value for code flow
+     * Expected response type of code for the authorization operation. Required by specification and the only allowed value for code flow
      */
     public static final String RESPONSE_TYPE_CODE = "code";
-
+    
 }

--- a/api/src/main/java/datawave/security/authorization/OAuthTokenResponse.java
+++ b/api/src/main/java/datawave/security/authorization/OAuthTokenResponse.java
@@ -1,0 +1,69 @@
+package datawave.security.authorization;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.xml.bind.annotation.*;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorOrder(XmlAccessOrder.ALPHABETICAL)
+public class OAuthTokenResponse {
+    
+    private String id_token;
+    private String access_token;
+    private String refresh_token;
+    private String expires_in;
+    private String token_type = "Bearer";
+    
+    @JsonCreator
+    public OAuthTokenResponse(@JsonProperty(value = "id_token", required = true) String id_token,
+                    @JsonProperty(value = "access_token", required = true) String access_token,
+                    @JsonProperty(value = "refresh_token", required = true) String refresh_token,
+                    @JsonProperty(value = "expires_in", required = true) long expires_in) {
+        this.id_token = id_token;
+        this.access_token = access_token;
+        this.refresh_token = refresh_token;
+        this.expires_in = Long.toString(expires_in);
+    }
+    
+    public void setId_token(String id_token) {
+        this.id_token = id_token;
+    }
+    
+    public String getId_token() {
+        return id_token;
+    }
+    
+    public void setAccess_token(String access_token) {
+        this.access_token = access_token;
+    }
+    
+    public String getAccess_token() {
+        return access_token;
+    }
+    
+    public void setRefresh_token(String refresh_token) {
+        this.refresh_token = refresh_token;
+    }
+    
+    public String getRefresh_token() {
+        return refresh_token;
+    }
+    
+    public void setExpires_in(String expires_in) {
+        this.expires_in = expires_in;
+    }
+    
+    public String getExpires_in() {
+        return expires_in;
+    }
+    
+    public void setToken_type(String token_type) {
+        this.token_type = token_type;
+    }
+    
+    public String getToken_type() {
+        return token_type;
+    }
+}

--- a/api/src/main/java/datawave/security/authorization/OAuthUserInfo.java
+++ b/api/src/main/java/datawave/security/authorization/OAuthUserInfo.java
@@ -1,0 +1,42 @@
+package datawave.security.authorization;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import datawave.security.authorization.DatawaveUser;
+import datawave.security.authorization.SubjectIssuerDNPair;
+import datawave.security.util.ProxiedEntityUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
+// Purpose of this class is to override the name field in DatawaveUser
+// to use the commonName instead of the subjectDN/issuerDN
+public class OAuthUserInfo extends DatawaveUser {
+    
+    private String name;
+    
+    public OAuthUserInfo(DatawaveUser user) {
+        super(user.getDn(), user.getUserType(), user.getEmail(), user.getAuths(), user.getRoles(), user.getRoleToAuthMapping(), user.getCreationTime(),
+                        user.getExpirationTime());
+        this.name = user.getCommonName();
+    }
+    
+    @JsonCreator
+    public OAuthUserInfo(@JsonProperty(value = "dn", required = true) SubjectIssuerDNPair dn,
+                    @JsonProperty(value = "userType", required = true) UserType userType, @JsonProperty(value = "email", required = true) String email,
+                    @JsonProperty("auths") Collection<String> auths, @JsonProperty("roles") Collection<String> roles,
+                    @JsonProperty("roleToAuthMapping") Multimap<String,String> roleToAuthMapping,
+                    @JsonProperty(value = "creationTime", defaultValue = "-1L") long creationTime,
+                    @JsonProperty(value = "expirationTime", defaultValue = "-1L") long expirationTime) {
+        super(dn, userType, email, auths, roles, roleToAuthMapping, creationTime, expirationTime);
+    }
+    
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,11 +18,17 @@
     </scm>
     <properties>
         <start-class>datawave.microservice.authorization.AuthorizationService</start-class>
+        <version.authorization-api>1.5-SNAPSHOT</version.authorization-api>
         <version.microservice.hazelcast-client>1.5</version.microservice.hazelcast-client>
         <version.microservice.starter>1.6.3</version.microservice.starter>
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>gov.nsa.datawave.microservice</groupId>
+                <artifactId>authorization-api</artifactId>
+                <version>${version.authorization-api}</version>
+            </dependency>
             <dependency>
                 <groupId>gov.nsa.datawave.microservice</groupId>
                 <artifactId>hazelcast-client</artifactId>
@@ -36,6 +42,10 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>gov.nsa.datawave.microservice</groupId>
+            <artifactId>authorization-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>gov.nsa.datawave.microservice</groupId>
             <artifactId>hazelcast-client</artifactId>

--- a/service/src/main/java/datawave/microservice/authorization/OAuthOperations.java
+++ b/service/src/main/java/datawave/microservice/authorization/OAuthOperations.java
@@ -1,0 +1,203 @@
+package datawave.microservice.authorization;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import datawave.microservice.authorization.oauth.*;
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+import datawave.security.authorization.*;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Presents the REST operations for the authorization service.
+ */
+@RestController
+@RequestMapping(path = "/v1/oauth", produces = MediaType.APPLICATION_JSON_VALUE)
+public class OAuthOperations {
+    private Logger log = LoggerFactory.getLogger(getClass());
+    private final JWTTokenHandler tokenHandler;
+    private final CachedDatawaveUserService cachedDatawaveUserService;
+    private final OAuthProperties oAuthProperties;
+    
+    private Cache<String,AuthorizationRequest> CACHE;
+    
+    @Autowired
+    public OAuthOperations(JWTTokenHandler tokenHandler, CachedDatawaveUserService cachedDatawaveUserService, OAuthProperties oAuthProperties) {
+        this.tokenHandler = tokenHandler;
+        this.cachedDatawaveUserService = cachedDatawaveUserService;
+        this.oAuthProperties = oAuthProperties;
+        long authCodeTtl = this.oAuthProperties.getAuthCodeTtl(TimeUnit.SECONDS);
+        if (authCodeTtl == -1) {
+            throw new IllegalStateException("authCodeTtl not configured.");
+        } else {
+            Caffeine<Object,Object> caffeine = Caffeine.newBuilder();
+            caffeine.expireAfterWrite(authCodeTtl, TimeUnit.SECONDS);
+            CACHE = caffeine.build();
+        }
+    }
+    
+    @ApiOperation(value = "Authorizes the calling user to produce a JWT value",
+                    notes = "The returned JWT can be passed to other calls in a header. For example: \"Authorization: bearer <JWT value>\".\n"
+                                    + "The user can be determined with from the supplied client certificate or trusted headers ("
+                                    + "X-SSL-clientcert-subject/X-SSL-clientcert-issuer).")
+    @RequestMapping(path = "/authorize", method = RequestMethod.GET)
+    public void authorize(@AuthenticationPrincipal ProxiedUserDetails currentUser, HttpServletResponse response, @RequestParam String client_id,
+                    @RequestParam String redirect_uri, @RequestParam String response_type, @RequestParam(required = false) String state)
+                    throws IllegalArgumentException, IOException {
+        
+        AuthorizedClient client = this.oAuthProperties.getAuthorizedClients().get(client_id);
+        if (client == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "unauthorized_client (client_id not registered)");
+            return;
+        }
+        if (!response_type.equalsIgnoreCase("code")) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "invalid_request (response_type must be 'code')");
+            return;
+        }
+        String code = RandomStringUtils.random(40, true, true);
+        CACHE.put(code, new AuthorizationRequest(currentUser, client, redirect_uri));
+        StringBuilder builder = new StringBuilder();
+        builder.append(redirect_uri);
+        builder.append("?");
+        builder.append("code=").append(code);
+        if (StringUtils.isNotBlank(state)) {
+            builder.append("&state=").append(state);
+        }
+        response.sendRedirect(builder.toString());
+    }
+    
+    @ApiOperation(value = "Authorizes the calling user to produce a JWT value",
+                    notes = "The returned JWT can be passed to other calls in a header. For example: \"Authorization: bearer <JWT value>\".\n"
+                                    + "The user can be determined with from the supplied client certificate or trusted headers ("
+                                    + "X-SSL-clientcert-subject/X-SSL-clientcert-issuer).")
+    @RequestMapping(path = "/token", method = RequestMethod.POST)
+    public OAuthTokenResponse token(@AuthenticationPrincipal ProxiedUserDetails currentUser, HttpServletResponse response, @RequestParam String grant_type,
+                    @RequestParam String client_id, @RequestParam String client_secret, @RequestParam(required = false) String code,
+                    @RequestParam(required = false) String refresh_token, @RequestParam(required = false) String redirect_uri) throws IOException {
+        
+        AuthorizedClient client = this.oAuthProperties.getAuthorizedClients().get(client_id);
+        if (client == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "unauthorized_client (client_id not registered)");
+            return null;
+        }
+        if (!client_secret.equals(client.getClient_secret())) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "unauthorized_client - (incorrect client_secret)");
+            return null;
+        }
+        
+        Collection<SubjectIssuerDNPair> userDnsToLookupAndAdd = new LinkedHashSet<>();
+        if (grant_type.equals("authorization_code")) {
+            if (StringUtils.isBlank(code)) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "invalid_request (must supply code for grant_type authorization_code)");
+                return null;
+            }
+            AuthorizationRequest authorizationRequest = CACHE.getIfPresent(code);
+            if (authorizationRequest == null) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "invalid_request (requested code not found)");
+                return null;
+            }
+            AuthorizedClient authorizedClient = authorizationRequest.getAuthorizedClient();
+            if (!authorizedClient.getClient_id().equals(client_id) || !authorizedClient.getClient_secret().equals(client_secret)) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "invalid_request (client_id/client_secret do not match authorize request)");
+                return null;
+            }
+            // a code can only be used once
+            CACHE.invalidate(code);
+            if (!redirect_uri.equals(authorizationRequest.getRedirect_uri())) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "invalid_request (redirect_uri must match the value when authorize was called)");
+                return null;
+            }
+            log.debug("Issuing a token for " + authorizationRequest.getProxiedUserDetails().getPrimaryUser().getCommonName() + " to "
+                            + client.getClient_name());
+            authorizationRequest.getProxiedUserDetails().getProxiedUsers().forEach(u -> userDnsToLookupAndAdd.add(u.getDn()));
+            // Add dn for the DN corresponding to the client that is invoking this call
+            // Required for authorization_code path, but not refresh_token path since all DNs will be in refresh token
+            currentUser.getProxiedUsers().forEach(u -> userDnsToLookupAndAdd.add(u.getDn()));
+        } else if (grant_type.equals("refresh_token")) {
+            if (StringUtils.isBlank(refresh_token)) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "invalid_request (must provide refresh_token for grant_type refresh_token)");
+                return null;
+            }
+            // Get the userDns from the princpals that were encoded in the resresh_token
+            List<DatawaveUser> usersInRefreshToken = new ArrayList<>();
+            try {
+                usersInRefreshToken.addAll(tokenHandler.createUsersFromToken(refresh_token, JWTTokenHandler.REFRESH_TOKEN_CLAIM));
+                for (DatawaveUser user : usersInRefreshToken) {
+                    userDnsToLookupAndAdd.add(user.getDn());
+                }
+            } catch (ExpiredJwtException e) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "invalid_grant (refresh_token expired)");
+                return null;
+            }
+            log.debug("Refreshing token for " + usersInRefreshToken.get(0).getCommonName() + " to " + client.getClient_name());
+        } else {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                            "invalid_grant (grant_type must be 'authorization_code' or 'refresh_token' " + grant_type + " not supported)");
+            return null;
+        }
+        Collection<DatawaveUser> proxiedUsers = new LinkedHashSet<>();
+        try {
+            // bypass the cache and lookup DatawaveUsers
+            proxiedUsers.addAll(cachedDatawaveUserService.lookup(userDnsToLookupAndAdd));
+        } catch (AuthorizationException e) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+            return null;
+        }
+        String name = proxiedUsers.stream().map(DatawaveUser::getName).collect(Collectors.joining(" -> "));
+        long now = System.currentTimeMillis();
+        Date idTokenExpire = new Date(now + this.oAuthProperties.getIdTokenTtl(TimeUnit.MILLISECONDS));
+        String idToken = tokenHandler.createTokenFromUsers(name, proxiedUsers, JWTTokenHandler.PRINCIPALS_CLAIM, idTokenExpire);
+        // Create DatawaveUsers with no auths, roles, or mapping for the refresh token
+        // The OAuth service can identify the user with this token, but it will have no auths/roles
+        // It is also serialized under a different claim ("refresh") than the access_token ("principals")
+        Date refreshTokenExpire = new Date(now + this.oAuthProperties.getRefreshTokenTtl(TimeUnit.MILLISECONDS));
+        Set<DatawaveUser> usersForRefreshToken = new LinkedHashSet<>();
+        for (DatawaveUser u : proxiedUsers) {
+            usersForRefreshToken.add(new DatawaveUser(u.getDn(), u.getUserType(), u.getEmail(), null, null, null, now));
+        }
+        String refreshToken = tokenHandler.createTokenFromUsers(name, usersForRefreshToken, JWTTokenHandler.REFRESH_TOKEN_CLAIM, refreshTokenExpire);
+        return new OAuthTokenResponse(idToken, idToken, refreshToken, this.oAuthProperties.getIdTokenTtl(TimeUnit.SECONDS));
+    }
+    
+    /**
+     * Returns the {@link ProxiedUserDetails} that represents the authenticated calling user.
+     */
+    @ApiOperation(value = "Returns details about the current primary user.",
+                    notes = "The user can be determined from the supplied client certificate, trusted headers ("
+                                    + "X-SSL-clientcert-subject/X-SSL-clientcert-issuer), or Authorization Bearer JWT."
+                                    + "Proxied user headers (X-ProxiedEntitiesChain/X-ProxiedIssuersChain) "
+                                    + "are also used to determine proxied users to include in the returned details.")
+    @RequestMapping(path = "/user", method = RequestMethod.GET)
+    public OAuthUserInfo user(@AuthenticationPrincipal ProxiedUserDetails currentUser) {
+        return new OAuthUserInfo(currentUser.getPrimaryUser());
+    }
+    
+    /**
+     * Returns the {@link ProxiedUserDetails} that represents the authenticated calling user.
+     */
+    @ApiOperation(value = "Returns details about the current user/proxied users.",
+                    notes = "The user can be determined from the supplied client certificate, trusted headers ("
+                                    + "X-SSL-clientcert-subject/X-SSL-clientcert-issuer), or Authorization Bearer JWT."
+                                    + "Proxied user headers (X-ProxiedEntitiesChain/X-ProxiedIssuersChain) "
+                                    + "are also used to determine proxied users to include in the returned details.")
+    @RequestMapping(path = "/users", method = RequestMethod.GET)
+    public Collection<OAuthUserInfo> users(@AuthenticationPrincipal ProxiedUserDetails currentUser) {
+        List<OAuthUserInfo> users = new ArrayList<>();
+        currentUser.getProxiedUsers().forEach(u -> users.add(new OAuthUserInfo(u)));
+        return users;
+    }
+}

--- a/service/src/main/java/datawave/microservice/authorization/OAuthOperations.java
+++ b/service/src/main/java/datawave/microservice/authorization/OAuthOperations.java
@@ -200,22 +200,22 @@ public class OAuthOperations {
         return users;
     }
     
-    public AuthorizationRequest getAuthorizationRequest(String code) {
+    private AuthorizationRequest getAuthorizationRequest(String code) {
         return this.authCache.get(code, AuthorizationRequest.class);
     }
     
-    public void putAuthorizationRequest(String code, AuthorizationRequest authRequest) {
+    private void putAuthorizationRequest(String code, AuthorizationRequest authRequest) {
         this.authCache.put(code, authRequest);
         this.authExpirationMap.put(code, (System.currentTimeMillis() + this.oAuthProperties.getAuthCodeTtl(TimeUnit.MILLISECONDS)));
     }
     
-    public void removeAuthorizationRequest(String code) {
+    private void removeAuthorizationRequest(String code) {
         this.authCache.evict(code);
         this.authExpirationMap.remove(code);
     }
     
     @Scheduled(fixedDelay = 1000)
-    public void expireAuthRequests() {
+    private void expireAuthRequests() {
         if (!authExpirationMap.isEmpty()) {
             long now = System.currentTimeMillis();
             synchronized (authExpirationMap) {

--- a/service/src/main/java/datawave/microservice/authorization/mock/MockDULProperties.java
+++ b/service/src/main/java/datawave/microservice/authorization/mock/MockDULProperties.java
@@ -1,5 +1,6 @@
 package datawave.microservice.authorization.mock;
 
+import org.apache.accumulo.core.client.mock.MockUser;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
@@ -11,7 +12,7 @@ import java.util.Map;
 public class MockDULProperties {
     private String serverDnRegex;
     private Map<String,String> globalRolesToAuths = new HashMap<>();
-    private Map<String,Map<String,String>> perUserRolesToAuths = new HashMap<>();
+    private Map<String,MockDatawaveUser> mockUsers = new HashMap<>();
     
     public String getServerDnRegex() {
         return serverDnRegex;
@@ -29,11 +30,11 @@ public class MockDULProperties {
         this.globalRolesToAuths = globalRolesToAuths;
     }
     
-    public Map<String,Map<String,String>> getPerUserRolesToAuths() {
-        return perUserRolesToAuths;
+    public void setMockUsers(Map<String,MockDatawaveUser> mockUsers) {
+        this.mockUsers = mockUsers;
     }
     
-    public void setPerUserRolesToAuths(Map<String,Map<String,String>> perUserRolesToAuths) {
-        this.perUserRolesToAuths = perUserRolesToAuths;
+    public Map<String,MockDatawaveUser> getMockUsers() {
+        return mockUsers;
     }
 }

--- a/service/src/main/java/datawave/microservice/authorization/mock/MockDatawaveUser.java
+++ b/service/src/main/java/datawave/microservice/authorization/mock/MockDatawaveUser.java
@@ -1,0 +1,26 @@
+package datawave.microservice.authorization.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockDatawaveUser {
+    
+    private Map<String,String> rolesToAuths = new HashMap<>();
+    private String email;
+    
+    public void setRolesToAuths(Map<String,String> rolesToAuths) {
+        this.rolesToAuths = rolesToAuths;
+    }
+    
+    public Map<String,String> getRolesToAuths() {
+        return rolesToAuths;
+    }
+    
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+}

--- a/service/src/main/java/datawave/microservice/authorization/mock/MockDatawaveUserLookup.java
+++ b/service/src/main/java/datawave/microservice/authorization/mock/MockDatawaveUserLookup.java
@@ -8,6 +8,7 @@ import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import static datawave.microservice.authorization.mock.MockDatawaveUserService.CACHE_NAME;
@@ -41,13 +42,19 @@ public class MockDatawaveUserLookup {
             userType = UserType.SERVER;
         }
         
-        Map<String,String> rolesToAuths = mockDULProperties.getPerUserRolesToAuths().get(dn.toString());
-        if (rolesToAuths == null) {
+        Map<String,String> rolesToAuths = new TreeMap<>();
+        String userEmail = null;
+        MockDatawaveUser mockDatawaveUser = mockDULProperties.getMockUsers().get(dn.toString());
+        if (mockDatawaveUser != null) {
+            rolesToAuths.putAll(mockDatawaveUser.getRolesToAuths());
+            userEmail = mockDatawaveUser.getEmail();
+        }
+        if (rolesToAuths.isEmpty()) {
             rolesToAuths = mockDULProperties.getGlobalRolesToAuths();
         }
         
         HashMultimap<String,String> mapping = HashMultimap.create();
         rolesToAuths.forEach(mapping::put);
-        return new DatawaveUser(dn, userType, rolesToAuths.values(), rolesToAuths.keySet(), mapping, System.currentTimeMillis());
+        return new DatawaveUser(dn, userType, userEmail, rolesToAuths.values(), rolesToAuths.keySet(), mapping, System.currentTimeMillis());
     }
 }

--- a/service/src/main/java/datawave/microservice/authorization/oauth/AuthorizationRequest.java
+++ b/service/src/main/java/datawave/microservice/authorization/oauth/AuthorizationRequest.java
@@ -1,0 +1,40 @@
+package datawave.microservice.authorization.oauth;
+
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+
+public class AuthorizationRequest {
+    
+    private ProxiedUserDetails proxiedUserDetails;
+    private AuthorizedClient authorizedClient;
+    private String redirect_uri;
+    
+    public AuthorizationRequest(ProxiedUserDetails proxiedUserDetails, AuthorizedClient authorizedClient, String redirect_uri) {
+        this.proxiedUserDetails = proxiedUserDetails;
+        this.authorizedClient = authorizedClient;
+        this.redirect_uri = redirect_uri;
+    }
+    
+    public ProxiedUserDetails getProxiedUserDetails() {
+        return proxiedUserDetails;
+    }
+    
+    public void setProxiedUserDetails(ProxiedUserDetails proxiedUserDetails) {
+        this.proxiedUserDetails = proxiedUserDetails;
+    }
+    
+    public void setAuthorizedClient(AuthorizedClient authorizedClient) {
+        this.authorizedClient = authorizedClient;
+    }
+    
+    public AuthorizedClient getAuthorizedClient() {
+        return authorizedClient;
+    }
+    
+    public void setRedirect_uri(String redirect_uri) {
+        this.redirect_uri = redirect_uri;
+    }
+    
+    public String getRedirect_uri() {
+        return redirect_uri;
+    }
+}

--- a/service/src/main/java/datawave/microservice/authorization/oauth/AuthorizedClient.java
+++ b/service/src/main/java/datawave/microservice/authorization/oauth/AuthorizedClient.java
@@ -1,0 +1,32 @@
+package datawave.microservice.authorization.oauth;
+
+public class AuthorizedClient {
+    
+    private String client_id;
+    private String client_name;
+    private String client_secret;
+    
+    public String getClient_id() {
+        return client_id;
+    }
+    
+    public void setClient_id(String client_id) {
+        this.client_id = client_id;
+    }
+    
+    public String getClient_name() {
+        return client_name;
+    }
+    
+    public void setClient_name(String client_name) {
+        this.client_name = client_name;
+    }
+    
+    public String getClient_secret() {
+        return client_secret;
+    }
+    
+    public void setClient_secret(String client_secret) {
+        this.client_secret = client_secret;
+    }
+}

--- a/service/src/main/java/datawave/microservice/authorization/oauth/OAuthProperties.java
+++ b/service/src/main/java/datawave/microservice/authorization/oauth/OAuthProperties.java
@@ -2,19 +2,29 @@ package datawave.microservice.authorization.oauth;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Component
+@Validated
 @ConfigurationProperties(prefix = "spring.security.datawave.oauth")
 public class OAuthProperties {
     
     private Map<String,AuthorizedClient> authorizedClients = new LinkedHashMap<>();
+    @NotNull
+    @Positive
     private long authCodeTtl = -1;
+    @NotNull
+    @Positive
     private long idTokenTtl = -1;
+    @NotNull
+    @Positive
     private long refreshTokenTtl = -1;
     
     public Map<String,AuthorizedClient> getAuthorizedClients() {

--- a/service/src/main/java/datawave/microservice/authorization/oauth/OAuthProperties.java
+++ b/service/src/main/java/datawave/microservice/authorization/oauth/OAuthProperties.java
@@ -1,0 +1,52 @@
+package datawave.microservice.authorization.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@ConfigurationProperties(prefix = "spring.security.datawave.oauth")
+public class OAuthProperties {
+    
+    private Map<String,AuthorizedClient> authorizedClients = new LinkedHashMap<>();
+    private long authCodeTtl = -1;
+    private long idTokenTtl = -1;
+    private long refreshTokenTtl = -1;
+    
+    public Map<String,AuthorizedClient> getAuthorizedClients() {
+        return authorizedClients;
+    }
+    
+    public void setAuthorizedClients(List<AuthorizedClient> authorizedClients) {
+        this.authorizedClients.clear();
+        authorizedClients.forEach(c -> this.authorizedClients.put(c.getClient_id(), c));
+    }
+    
+    public void setAuthCodeTtl(long authCodeTtl) {
+        this.authCodeTtl = authCodeTtl;
+    }
+    
+    public long getAuthCodeTtl(TimeUnit timeUnit) {
+        return timeUnit.convert(authCodeTtl, TimeUnit.SECONDS);
+    }
+    
+    public void setIdTokenTtl(long idTokenTtl) {
+        this.idTokenTtl = idTokenTtl;
+    }
+    
+    public long getIdTokenTtl(TimeUnit timeUnit) {
+        return timeUnit.convert(idTokenTtl, TimeUnit.SECONDS);
+    }
+    
+    public void setRefreshTokenTtl(long refreshTokenTtl) {
+        this.refreshTokenTtl = refreshTokenTtl;
+    }
+    
+    public long getRefreshTokenTtl(TimeUnit timeUnit) {
+        return timeUnit.convert(refreshTokenTtl, TimeUnit.SECONDS);
+    }
+}

--- a/service/src/test/java/datawave/microservice/authorization/AuthorizationServiceTest.java
+++ b/service/src/test/java/datawave/microservice/authorization/AuthorizationServiceTest.java
@@ -28,9 +28,11 @@ import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.util.UriComponents;
@@ -44,9 +46,9 @@ import static datawave.security.authorization.DatawaveUser.UserType.USER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-//@Category(IntegrationTest.class)
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"AuthorizationServiceTest"})
 public class AuthorizationServiceTest {
     private static final SubjectIssuerDNPair DN = SubjectIssuerDNPair.of("userDn", "issuerDn");
     
@@ -69,7 +71,7 @@ public class AuthorizationServiceTest {
     
     @Test
     public void testAdminMethodSecurity() throws Exception {
-        DatawaveUser unuathDWUser = new DatawaveUser(DN, USER, null, null, null, System.currentTimeMillis());
+        DatawaveUser unuathDWUser = new DatawaveUser(DN, USER, null, null, null, null, System.currentTimeMillis());
         ProxiedUserDetails unuathUser = new ProxiedUserDetails(Collections.singleton(unuathDWUser), unuathDWUser.getCreationTime());
         
         testAdminMethodFailure(unuathUser, "/authorization/v1/admin/evictAll", null);
@@ -80,7 +82,7 @@ public class AuthorizationServiceTest {
         testAdminMethodFailure(unuathUser, "/authorization/v1/admin/listUsersMatching", "substring=ignore");
         
         Collection<String> roles = Collections.singleton("Administrator");
-        DatawaveUser authDWUser = new DatawaveUser(DN, USER, null, roles, null, System.currentTimeMillis());
+        DatawaveUser authDWUser = new DatawaveUser(DN, USER, null, null, roles, null, System.currentTimeMillis());
         ProxiedUserDetails authUser = new ProxiedUserDetails(Collections.singleton(authDWUser), authDWUser.getCreationTime());
         
         testAdminMethodSuccess(authUser, "/authorization/v1/admin/evictAll", null);
@@ -111,6 +113,7 @@ public class AuthorizationServiceTest {
     @ImportAutoConfiguration({RefreshAutoConfiguration.class})
     @AutoConfigureCache(cacheProvider = CacheType.HAZELCAST)
     @ComponentScan(basePackages = "datawave.microservice")
+    @Profile("AuthorizationServiceTest")
     @Configuration
     public static class AuthorizationServiceTestConfiguration {
         @Bean
@@ -139,7 +142,7 @@ public class AuthorizationServiceTest {
         
         @Override
         public Collection<DatawaveUser> lookup(Collection<SubjectIssuerDNPair> dns) throws AuthorizationException {
-            return dns.stream().map(dn -> new DatawaveUser(dn, USER, null, null, null, -1L)).collect(Collectors.toList());
+            return dns.stream().map(dn -> new DatawaveUser(dn, USER, null, null, null, null, -1L)).collect(Collectors.toList());
         }
         
         @Override

--- a/service/src/test/java/datawave/microservice/authorization/OAuthOperationsTest.java
+++ b/service/src/test/java/datawave/microservice/authorization/OAuthOperationsTest.java
@@ -1,0 +1,525 @@
+package datawave.microservice.authorization;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import datawave.microservice.authorization.jwt.JWTRestTemplate;
+import datawave.security.authorization.OAuthTokenResponse;
+import datawave.security.authorization.OAuthUserInfo;
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+import datawave.microservice.config.web.RestClientProperties;
+import datawave.security.authorization.*;
+import datawave.security.util.ProxiedEntityUtils;
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.cache.CacheType;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.*;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.*;
+
+import static datawave.security.authorization.DatawaveUser.UserType.SERVER;
+import static datawave.security.authorization.DatawaveUser.UserType.USER;
+import static java.util.stream.Collectors.toList;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "spring.main.allow-bean-definition-overriding=true")
+@ActiveProfiles({"OAuthServiceTest"})
+public class OAuthOperationsTest {
+    private static final SubjectIssuerDNPair DN = SubjectIssuerDNPair.of("userDn", "issuerDn");
+    
+    @LocalServerPort
+    private int webServicePort;
+    
+    @Autowired
+    private RestTemplateBuilder restTemplateBuilder;
+    
+    @Autowired
+    private JWTTokenHandler jwtTokenHandler;
+    
+    @Autowired
+    private SSLContext sslContext;
+    
+    @Autowired
+    private RestClientProperties restClientProperties;
+    
+    private JWTRestTemplate jwtRestTemplate;
+    
+    private static Map<SubjectIssuerDNPair,DatawaveUser> userMap = new LinkedHashMap<>();
+    private final SubjectIssuerDNPair userDN = SubjectIssuerDNPair.of("cn=Test User, ou=testing, ou=development, o=testcorp, c=us",
+                    "cn=testcorp ca, ou=security, o=testcorp, c=us");
+    private final SubjectIssuerDNPair serverDN = SubjectIssuerDNPair.of("cn=test.testcorp.com, ou=microservices, ou=development, o=testcorp, c=us",
+                    "cn=testcorp ca, ou=security, o=testcorp, c=us");
+    private final String CLIENT_ID = "123456789";
+    private final String CLIENT_SECRET = "secret";
+    private final String REDIRECT_URI = "https://localhost/redirect";
+    
+    @Before
+    public void setup() {
+        userMap.put(userDN,
+                        new DatawaveUser(userDN, USER, null, Arrays.asList("A", "B", "E"), Arrays.asList("AuthorizedUser"), null, System.currentTimeMillis()));
+        userMap.put(serverDN, new DatawaveUser(serverDN, SERVER, null, Arrays.asList("A", "B", "C", "D"), Arrays.asList("AuthorizedServer"), null,
+                        System.currentTimeMillis()));
+        OAuthRestTemplateCustomizer customizer = new OAuthRestTemplateCustomizer(sslContext, restClientProperties);
+        // Disable following redirects
+        restTemplateBuilder = restTemplateBuilder.additionalCustomizers(customizer);
+        jwtRestTemplate = restTemplateBuilder.build(JWTRestTemplate.class);
+    }
+    
+    @Test
+    public void TestCodeFlowValid() throws Exception {
+        DatawaveUser dwUser = userMap.get(userDN);
+        DatawaveUser dwServer = userMap.get(serverDN);
+        
+        // Application redirects user's browser to the authorize endpoint (redirect not shown)
+        // The user calls authorize with own credentials and gets redirected back to the application
+        // This test is set up to not follow the redirect so that we can test the response
+        String state = "randomstatestring";
+        ResponseEntity<String> authorizeEntity = authorize(dwUser, "code", CLIENT_ID, REDIRECT_URI, state);
+        Assert.assertEquals("Expecting a 302 redirect", 302, authorizeEntity.getStatusCode().value());
+        List<String> valueList = authorizeEntity.getHeaders().get("Location");
+        Assert.assertEquals(1, valueList.size());
+        Assert.assertTrue("Redirect location should start with redirect_uri", valueList.get(0).startsWith(REDIRECT_URI));
+        
+        Map<String,List<String>> queryParams = splitQuery(new URL(valueList.get(0)));
+        List<String> stateList = queryParams.get("state");
+        Assert.assertEquals(1, stateList.size());
+        Assert.assertEquals("If state parameter is send, it should be returned", state, stateList.get(0));
+        List<String> codeList = queryParams.get("code");
+        Assert.assertEquals(1, codeList.size());
+        
+        // This is the short-lived code that an application needs to get a user's token
+        String code = codeList.get(0);
+        
+        // After the user's browser gets redirected to the application, the application now has the code
+        // and can call the token endpoint to get this user's token
+        ResponseEntity<OAuthTokenResponse> tokenEntity = token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        Assert.assertEquals(200, tokenEntity.getStatusCode().value());
+        
+        OAuthTokenResponse OAuthTokenResponse = tokenEntity.getBody();
+        Assert.assertEquals(200, tokenEntity.getStatusCode().value());
+        
+        String access_token = OAuthTokenResponse.getAccess_token();
+        Collection<DatawaveUser> usersFromToken = jwtTokenHandler.createUsersFromToken(access_token);
+        // The DatawaveUser of both the user and the server should be in the token
+        // The server is proxying for the user and must also be authenticated
+        Assert.assertEquals(2, usersFromToken.size());
+        
+        // Call the user endpoint with the access_token to get the primary user
+        ResponseEntity<OAuthUserInfo> userResponse = user(access_token, JWTTokenHandler.PRINCIPALS_CLAIM);
+        OAuthUserInfo OAuthUserInfo = userResponse.getBody();
+        Assert.assertEquals(ProxiedEntityUtils.getCommonName(dwUser.getDn().subjectDN()), OAuthUserInfo.getName());
+        Assert.assertEquals(dwUser.getLogin(), OAuthUserInfo.getLogin());
+        Assert.assertEquals(dwUser.getEmail(), OAuthUserInfo.getEmail());
+        Assert.assertEquals(dwUser.getDn(), OAuthUserInfo.getDn());
+        Assert.assertEquals(dwUser.getCreationTime(), OAuthUserInfo.getCreationTime());
+        
+        // Call the users endpoint with the access_token to get the all users
+        ResponseEntity<OAuthUserInfo[]> usersResponse = users(access_token, JWTTokenHandler.PRINCIPALS_CLAIM);
+        OAuthUserInfo[] users = usersResponse.getBody();
+        Assert.assertNotNull(users);
+        Assert.assertEquals("Primary and proxying user should be returned", 2, users.length);
+        
+        // Call the token endpoint with the refresh token id
+        String refresh_token = OAuthTokenResponse.getRefresh_token();
+        ResponseEntity<OAuthTokenResponse> refreshedTokenEntity = token(dwServer, "refresh_token", CLIENT_ID, CLIENT_SECRET, null, null, refresh_token);
+        Assert.assertEquals(200, refreshedTokenEntity.getStatusCode().value());
+    }
+    
+    @Test
+    public void TestCodeFlowInvalidClientId() {
+        DatawaveUser dwUser = userMap.get(userDN);
+        
+        // Application redirects user's browser to the authorize endpoint (redirect not shown)
+        // The user calls authorize with own credentials and gets redirected back to the application
+        // This test is set up to not follow the redirect so that we can test the response
+        try {
+            authorize(dwUser, "code", "00000000", REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwUser, "authorization_code", "00000000", CLIENT_SECRET, "wrongcode", REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+    }
+    
+    @Test
+    public void TestCodeFlowMissingResponseType() {
+        DatawaveUser dwUser = userMap.get(userDN);
+        
+        // Application redirects user's browser to the authorize endpoint (redirect not shown)
+        // The user calls authorize with own credentials and gets redirected back to the application
+        // This test is set up to not follow the redirect so that we can test the response
+        try {
+            authorize(dwUser, null, CLIENT_ID, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+    }
+    
+    @Test
+    public void TestCodeFlowMissingRedirectUri() {
+        DatawaveUser dwUser = userMap.get(userDN);
+        
+        // Application redirects user's browser to the authorize endpoint (redirect not shown)
+        // The user calls authorize with own credentials and gets redirected back to the application
+        // This test is set up to not follow the redirect so that we can test the response
+        try {
+            authorize(dwUser, "code", CLIENT_ID, null, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+    }
+    
+    @Test
+    public void TestCodeFlowWrongCode() {
+        DatawaveUser dwServer = userMap.get(serverDN);
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, "wrongcode", REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+    }
+    
+    @Test
+    public void TestCodeFlowRightCodeWrongOtherParameters() throws Exception {
+        DatawaveUser dwUser = userMap.get(userDN);
+        DatawaveUser dwServer = userMap.get(serverDN);
+        
+        // Application redirects user's browser to the authorize endpoint (redirect not shown)
+        // The user calls authorize with own credentials and gets redirected back to the application
+        // This test is set up to not follow the redirect so that we can test the response
+        ResponseEntity<String> authorizeEntity = authorize(dwUser, "code", CLIENT_ID, REDIRECT_URI, null);
+        Assert.assertEquals(302, authorizeEntity.getStatusCode().value());
+        List<String> valueList = authorizeEntity.getHeaders().get("Location");
+        Assert.assertEquals(1, valueList.size());
+        Assert.assertTrue(valueList.get(0).startsWith(REDIRECT_URI));
+        
+        Map<String,List<String>> queryParams = splitQuery(new URL(valueList.get(0)));
+        List<String> codeList = queryParams.get("code");
+        Assert.assertEquals(1, codeList.size());
+        
+        // This is the short-lived code that an application needs to get a user's token
+        String code = codeList.get(0);
+        
+        try {
+            token(dwServer, "invalid_grant_type", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", "invalidClientId", CLIENT_SECRET, code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, "wrongsecret", code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, "https://different_redirect", null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+    }
+    
+    @Test
+    public void TestCodeFlowUseCodeTwice() throws Exception {
+        DatawaveUser dwUser = userMap.get(userDN);
+        DatawaveUser dwServer = userMap.get(serverDN);
+        
+        // Application redirects user's browser to the authorize endpoint (redirect not shown)
+        // The user calls authorize with own credentials and gets redirected back to the application
+        // This test is set up to not follow the redirect so that we can test the response
+        ResponseEntity<String> authorizeEntity = authorize(dwUser, "code", CLIENT_ID, REDIRECT_URI, null);
+        Assert.assertEquals(302, authorizeEntity.getStatusCode().value());
+        List<String> valueList = authorizeEntity.getHeaders().get("Location");
+        Assert.assertEquals(1, valueList.size());
+        Assert.assertTrue(valueList.get(0).startsWith(REDIRECT_URI));
+        
+        Map<String,List<String>> queryParams = splitQuery(new URL(valueList.get(0)));
+        List<String> codeList = queryParams.get("code");
+        Assert.assertEquals(1, codeList.size());
+        
+        // This is the short-lived code that an application needs to get a user's token
+        String code = codeList.get(0);
+        
+        // After the user's browser gets redirected to the application, the application now has the code
+        // and can call the token endpoint to get this user's token
+        ResponseEntity<OAuthTokenResponse> tokenEntity = token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        Assert.assertEquals(200, tokenEntity.getStatusCode().value());
+        
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals("Code should only be valid for one call", HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", "invalidClientId", CLIENT_SECRET, code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, "wrongsecret", code, REDIRECT_URI, null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+        
+        try {
+            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, "https://different_redirect", null);
+        } catch (HttpStatusCodeException e) {
+            Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        }
+    }
+    
+    private ResponseEntity<String> authorize(DatawaveUser user, String response_type, String client_id, String redirect_uri, String state) {
+        ProxiedUserDetails authUser = new ProxiedUserDetails(Collections.singleton(user), user.getCreationTime());
+        MultiValueMap<String,String> queryParams = new LinkedMultiValueMap<>();
+        if (response_type != null) {
+            queryParams.put("response_type", Collections.singletonList(response_type));
+        }
+        if (client_id != null) {
+            queryParams.put("client_id", Collections.singletonList(client_id));
+        }
+        if (redirect_uri != null) {
+            queryParams.put("redirect_uri", Collections.singletonList(redirect_uri));
+        }
+        if (state != null) {
+            queryParams.put("state", Collections.singletonList(state));
+        }
+        UriComponents authorizeUri = UriComponentsBuilder.newInstance().scheme("https").host("localhost").port(webServicePort)
+                        .path("/authorization/v1/oauth/authorize").queryParams(queryParams).build();
+        return jwtRestTemplate.exchange(authUser, HttpMethod.GET, authorizeUri, String.class);
+    }
+    
+    private ResponseEntity<OAuthTokenResponse> token(DatawaveUser user, String grant_type, String client_id, String client_secret, String code,
+                    String redirect_uri, String refresh_token) {
+        ProxiedUserDetails authUser = new ProxiedUserDetails(Collections.singleton(user), user.getCreationTime());
+        MultiValueMap<String,String> queryParams = new LinkedMultiValueMap<>();
+        if (grant_type != null) {
+            queryParams.put("grant_type", Collections.singletonList(grant_type));
+        }
+        if (client_id != null) {
+            queryParams.put("client_id", Collections.singletonList(client_id));
+        }
+        if (client_secret != null) {
+            queryParams.put("client_secret", Collections.singletonList(client_secret));
+        }
+        if (redirect_uri != null) {
+            queryParams.put("redirect_uri", Collections.singletonList(redirect_uri));
+        }
+        if (code != null) {
+            queryParams.put("code", Collections.singletonList(code));
+        }
+        if (refresh_token != null) {
+            queryParams.put("refresh_token", Collections.singletonList(refresh_token));
+        }
+        UriComponents tokenUri = UriComponentsBuilder.newInstance().scheme("https").host("localhost").port(webServicePort).path("/authorization/v1/oauth/token")
+                        .queryParams(queryParams).build();
+        
+        return jwtRestTemplate.exchange(authUser, HttpMethod.POST, tokenUri, OAuthTokenResponse.class);
+    }
+    
+    private ResponseEntity<OAuthUserInfo> user(String token, String claim) {
+        Collection<DatawaveUser> dwUsers = jwtTokenHandler.createUsersFromToken(token, claim);
+        ProxiedUserDetails authUser = new ProxiedUserDetails(dwUsers, dwUsers.stream().findFirst().get().getCreationTime());
+        UriComponents userUri = UriComponentsBuilder.newInstance().scheme("https").host("localhost").port(webServicePort).path("/authorization/v1/oauth/user")
+                        .build();
+        return jwtRestTemplate.exchange(authUser, HttpMethod.GET, userUri, OAuthUserInfo.class);
+    }
+    
+    private ResponseEntity<OAuthUserInfo[]> users(String token, String claim) {
+        Collection<DatawaveUser> dwUsers = jwtTokenHandler.createUsersFromToken(token, claim);
+        ProxiedUserDetails authUser = new ProxiedUserDetails(dwUsers, dwUsers.stream().findFirst().get().getCreationTime());
+        UriComponents userUri = UriComponentsBuilder.newInstance().scheme("https").host("localhost").port(webServicePort).path("/authorization/v1/oauth/users")
+                        .build();
+        return jwtRestTemplate.exchange(authUser, HttpMethod.GET, userUri, OAuthUserInfo[].class);
+    }
+    
+    public static Map<String,List<String>> splitQuery(URL url) throws UnsupportedEncodingException {
+        final Map<String,List<String>> query_pairs = new LinkedHashMap<>();
+        final String[] pairs = url.getQuery().split("&");
+        for (String pair : pairs) {
+            final int idx = pair.indexOf("=");
+            final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
+            if (!query_pairs.containsKey(key)) {
+                query_pairs.put(key, new LinkedList<>());
+            }
+            final String value = idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8") : null;
+            query_pairs.get(key).add(value);
+        }
+        return query_pairs;
+    }
+    
+    @ImportAutoConfiguration({RefreshAutoConfiguration.class})
+    @AutoConfigureCache(cacheProvider = CacheType.HAZELCAST)
+    @ComponentScan(basePackages = "datawave.microservice")
+    @Profile("OAuthServiceTest")
+    @Configuration
+    public static class AuthorizationServiceTestConfiguration {
+        @Bean
+        public CachedDatawaveUserService oauthCachedDatawaveUserService() {
+            return new TestUserService(OAuthOperationsTest.userMap);
+        }
+        
+        @Bean
+        public HazelcastInstance testHazelcastInstance() {
+            Config config = new Config();
+            config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+            return Hazelcast.newHazelcastInstance(config);
+        }
+    }
+    
+    @EnableCaching
+    @CacheConfig(cacheNames = "datawaveUsers-IT")
+    private static class TestUserService implements CachedDatawaveUserService {
+        
+        private Map<SubjectIssuerDNPair,DatawaveUser> userMap;
+        
+        public TestUserService(Map<SubjectIssuerDNPair,DatawaveUser> userMap) {
+            this.userMap = userMap;
+        }
+        
+        @Override
+        public Collection<DatawaveUser> lookup(Collection<SubjectIssuerDNPair> dns) throws AuthorizationException {
+            return dns.stream().map(dn -> this.userMap.get(dn)).collect(toList());
+        }
+        
+        @Override
+        public Collection<DatawaveUser> reload(Collection<SubjectIssuerDNPair> dns) throws AuthorizationException {
+            return null;
+        }
+        
+        @Override
+        public DatawaveUser list(String name) {
+            return null;
+        }
+        
+        @Override
+        public Collection<? extends DatawaveUserInfo> listAll() {
+            return null;
+        }
+        
+        @Override
+        public Collection<? extends DatawaveUserInfo> listMatching(String substring) {
+            return null;
+        }
+        
+        @Override
+        public String evict(String name) {
+            return null;
+        }
+        
+        @Override
+        public String evictMatching(String substring) {
+            return null;
+        }
+        
+        @Override
+        public String evictAll() {
+            return null;
+        }
+    }
+    
+    /*
+     * Only used for the OAuth tests so that we can ignore redirect responses and check the response values at each step of the OAuth process
+     */
+    public class OAuthRestTemplateCustomizer implements RestTemplateCustomizer {
+        
+        private final SSLContext sslContext;
+        private final int maxConnectionsTotal;
+        private final int maxConnectionsPerRoute;
+        
+        public OAuthRestTemplateCustomizer(SSLContext sslContext, RestClientProperties restClientProperties) {
+            this.sslContext = sslContext;
+            this.maxConnectionsTotal = restClientProperties.getMaxConnectionsTotal();
+            this.maxConnectionsPerRoute = restClientProperties.getMaxConnectionsPerRoute();
+        }
+        
+        @Override
+        public void customize(RestTemplate restTemplate) {
+            restTemplate.setRequestFactory(clientHttpRequestFactory());
+        }
+        
+        protected ClientHttpRequestFactory clientHttpRequestFactory() {
+            HttpClient httpClient = customizeHttpClient(HttpClients.custom(), sslContext).build();
+            return new HttpComponentsClientHttpRequestFactory(httpClient);
+        }
+        
+        protected HttpClientBuilder customizeHttpClient(HttpClientBuilder httpClientBuilder, SSLContext sslContext) {
+            if (sslContext != null) {
+                httpClientBuilder.setSSLContext(sslContext);
+            }
+            httpClientBuilder.setMaxConnTotal(maxConnectionsTotal);
+            httpClientBuilder.setMaxConnPerRoute(maxConnectionsPerRoute);
+            httpClientBuilder.disableRedirectHandling();
+            // TODO: We're allowing all hosts, since the cert presented by the service we're calling likely won't match its hostname (e.g., a docker host name)
+            // Instead, we could list the expected cert as a property (or use our server cert), and verify that the presented name matches.
+            return httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+        }
+    }
+    
+    private static class NoOpResponseErrorHandler extends DefaultResponseErrorHandler {
+        
+        @Override
+        public void handleError(ClientHttpResponse response) throws IOException {}
+        
+    }
+}

--- a/service/src/test/java/datawave/microservice/authorization/OAuthOperationsTest.java
+++ b/service/src/test/java/datawave/microservice/authorization/OAuthOperationsTest.java
@@ -56,6 +56,7 @@ import java.util.*;
 
 import static datawave.security.authorization.DatawaveUser.UserType.SERVER;
 import static datawave.security.authorization.DatawaveUser.UserType.USER;
+import static datawave.security.authorization.OAuthConstants.*;
 import static java.util.stream.Collectors.toList;
 
 @RunWith(SpringRunner.class)
@@ -111,7 +112,7 @@ public class OAuthOperationsTest {
         // The user calls authorize with own credentials and gets redirected back to the application
         // This test is set up to not follow the redirect so that we can test the response
         String state = "randomstatestring";
-        ResponseEntity<String> authorizeEntity = authorize(dwUser, "code", CLIENT_ID, REDIRECT_URI, state);
+        ResponseEntity<String> authorizeEntity = authorize(dwUser, RESPONSE_TYPE_CODE, CLIENT_ID, REDIRECT_URI, state);
         Assert.assertEquals("Expecting a 302 redirect", 302, authorizeEntity.getStatusCode().value());
         List<String> valueList = authorizeEntity.getHeaders().get("Location");
         Assert.assertEquals(1, valueList.size());
@@ -129,7 +130,7 @@ public class OAuthOperationsTest {
         
         // After the user's browser gets redirected to the application, the application now has the code
         // and can call the token endpoint to get this user's token
-        ResponseEntity<OAuthTokenResponse> tokenEntity = token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        ResponseEntity<OAuthTokenResponse> tokenEntity = token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
         Assert.assertEquals(200, tokenEntity.getStatusCode().value());
         
         OAuthTokenResponse OAuthTokenResponse = tokenEntity.getBody();
@@ -158,7 +159,7 @@ public class OAuthOperationsTest {
         
         // Call the token endpoint with the refresh token id
         String refresh_token = OAuthTokenResponse.getRefresh_token();
-        ResponseEntity<OAuthTokenResponse> refreshedTokenEntity = token(dwServer, "refresh_token", CLIENT_ID, CLIENT_SECRET, null, null, refresh_token);
+        ResponseEntity<OAuthTokenResponse> refreshedTokenEntity = token(dwServer, GRANT_REFRESH_TOKEN, CLIENT_ID, CLIENT_SECRET, null, null, refresh_token);
         Assert.assertEquals(200, refreshedTokenEntity.getStatusCode().value());
     }
     
@@ -170,13 +171,13 @@ public class OAuthOperationsTest {
         // The user calls authorize with own credentials and gets redirected back to the application
         // This test is set up to not follow the redirect so that we can test the response
         try {
-            authorize(dwUser, "code", "00000000", REDIRECT_URI, null);
+            authorize(dwUser, RESPONSE_TYPE_CODE, "00000000", REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwUser, "authorization_code", "00000000", CLIENT_SECRET, "wrongcode", REDIRECT_URI, null);
+            token(dwUser, GRANT_AUTHORIZATION_CODE, "00000000", CLIENT_SECRET, "wrongcode", REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
@@ -204,7 +205,7 @@ public class OAuthOperationsTest {
         // The user calls authorize with own credentials and gets redirected back to the application
         // This test is set up to not follow the redirect so that we can test the response
         try {
-            authorize(dwUser, "code", CLIENT_ID, null, null);
+            authorize(dwUser, RESPONSE_TYPE_CODE, CLIENT_ID, null, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
@@ -214,7 +215,7 @@ public class OAuthOperationsTest {
     public void TestCodeFlowWrongCode() {
         DatawaveUser dwServer = userMap.get(serverDN);
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, "wrongcode", REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, "wrongcode", REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
@@ -228,7 +229,7 @@ public class OAuthOperationsTest {
         // Application redirects user's browser to the authorize endpoint (redirect not shown)
         // The user calls authorize with own credentials and gets redirected back to the application
         // This test is set up to not follow the redirect so that we can test the response
-        ResponseEntity<String> authorizeEntity = authorize(dwUser, "code", CLIENT_ID, REDIRECT_URI, null);
+        ResponseEntity<String> authorizeEntity = authorize(dwUser, RESPONSE_TYPE_CODE, CLIENT_ID, REDIRECT_URI, null);
         Assert.assertEquals(302, authorizeEntity.getStatusCode().value());
         List<String> valueList = authorizeEntity.getHeaders().get("Location");
         Assert.assertEquals(1, valueList.size());
@@ -248,25 +249,25 @@ public class OAuthOperationsTest {
         }
         
         try {
-            token(dwServer, "authorization_code", "invalidClientId", CLIENT_SECRET, code, REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, "invalidClientId", CLIENT_SECRET, code, REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, "wrongsecret", code, REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, "wrongsecret", code, REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, "https://different_redirect", null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, code, "https://different_redirect", null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
@@ -280,7 +281,7 @@ public class OAuthOperationsTest {
         // Application redirects user's browser to the authorize endpoint (redirect not shown)
         // The user calls authorize with own credentials and gets redirected back to the application
         // This test is set up to not follow the redirect so that we can test the response
-        ResponseEntity<String> authorizeEntity = authorize(dwUser, "code", CLIENT_ID, REDIRECT_URI, null);
+        ResponseEntity<String> authorizeEntity = authorize(dwUser, RESPONSE_TYPE_CODE, CLIENT_ID, REDIRECT_URI, null);
         Assert.assertEquals(302, authorizeEntity.getStatusCode().value());
         List<String> valueList = authorizeEntity.getHeaders().get("Location");
         Assert.assertEquals(1, valueList.size());
@@ -295,35 +296,35 @@ public class OAuthOperationsTest {
         
         // After the user's browser gets redirected to the application, the application now has the code
         // and can call the token endpoint to get this user's token
-        ResponseEntity<OAuthTokenResponse> tokenEntity = token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+        ResponseEntity<OAuthTokenResponse> tokenEntity = token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
         Assert.assertEquals(200, tokenEntity.getStatusCode().value());
         
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals("Code should only be valid for one call", HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwServer, "authorization_code", "invalidClientId", CLIENT_SECRET, code, REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, "invalidClientId", CLIENT_SECRET, code, REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, code, REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, "wrongsecret", code, REDIRECT_URI, null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, "wrongsecret", code, REDIRECT_URI, null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }
         
         try {
-            token(dwServer, "authorization_code", CLIENT_ID, CLIENT_SECRET, code, "https://different_redirect", null);
+            token(dwServer, GRANT_AUTHORIZATION_CODE, CLIENT_ID, CLIENT_SECRET, code, "https://different_redirect", null);
         } catch (HttpStatusCodeException e) {
             Assert.assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
         }

--- a/service/src/test/resources/config/application.yml
+++ b/service/src/test/resources/config/application.yml
@@ -9,7 +9,14 @@ spring:
       issuers-required: true
       allowed-callers:
         - "cn=test.testcorp.com, ou=microservices, ou=development, o=testcorp, c=us<cn=testcorp ca, ou=security, o=testcorp, c=us>"
-
+      oauth:
+        authCodeTtl: 60
+        idTokenTtl: 86400
+        refreshTokenTtl: 604800
+        authorizedClients:
+          - client_name: localhost
+            client_id: 123456789
+            client_secret: secret
 server:
   port: 0
   non-secure-port: 0

--- a/service/src/test/resources/ehcache.xml
+++ b/service/src/test/resources/ehcache.xml
@@ -5,4 +5,9 @@
         maxElementsInMemory="1"
         diskPersistent="false">
     </cache>
+    <cache
+        name="oauthAuthorizations"
+        maxElementsInMemory="10"
+        diskPersistent="false">
+    </cache>
 </ehcache>


### PR DESCRIPTION
closes #1 Add OAuth2 methods to allow integration with OAuth2 clients

These operations will support the OAuth 2.0 Authorization Code Grant described here:
https://tools.ietf.org/html/rfc6749

Added some comments to aid in the review.